### PR TITLE
Bounds not saved problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ js
 *.html
 *.app
 yarn.lock
+/.idea

--- a/coffee/main.coffee
+++ b/coffee/main.coffee
@@ -125,7 +125,7 @@ onWinResize = (event) ->
         if b.width != b.height
             b.width = b.height = Math.min b.width, b.height 
             win.setBounds b
-            saveBounds()
+        saveBounds()
     squareTimer = setTimeout adjustSize, 300
     
 showAbout = ->


### PR DESCRIPTION
Hi Kodi,

the problem with the unsaved bounds only happend after toggling between small an big sizes with command-o.
I fixed this in the onWinResize method by moving the saveBounds method out of the width != height condition ;-)
Would you be so kind to merge this?

Best regards,

Jan